### PR TITLE
Fix for some of the dependencies

### DIFF
--- a/lisp/circe-pkg.el.in
+++ b/lisp/circe-pkg.el.in
@@ -1,4 +1,3 @@
 (define-package "circe" "$VERSION"
                 "Client for IRC in Emacs"
-                '((tracking "0")
-                  ))
+                '((lui "0") (lcs "0")))

--- a/lisp/lui-pkg.el.in
+++ b/lisp/lui-pkg.el.in
@@ -1,5 +1,3 @@
 (define-package "lui" "$VERSION"
                 "Linewise User Interface"
-                '((lui "0")
-                  (lcs "0")
-                  ))
+                '((tracking "0")))

--- a/lisp/tracking.el
+++ b/lisp/tracking.el
@@ -5,7 +5,7 @@
 ;; Version: 1.2
 ;; Author: Jorgen Schaefer <forcer@forcix.cx>
 ;; URL: https://github.com/jorgenschaefer/circe/wiki/Tracking
-;; Requirements: ((shorten "0.1"))
+;; Package-Requires: ((shorten "0.1"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- `circe` requires `lcs` and `lui`
- `lui` requires `tracking`
- `tracking` requires `shorten`
