### PR TITLE
git: ignore *.elc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /release
+*.elc


### PR DESCRIPTION
Adds *.elc to .gitignore.  Useful when people use el-get
to install circe.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
