### PR TITLE
Don't accidentally set buffer-local `mode-line-format'.

### DIFF
--- a/lisp/tracking.el
+++ b/lisp/tracking.el
@@ -189,9 +189,9 @@ line. The user can cycle through them using
               'tracking-remove-visible-buffers))
    (t
     (setq mode-line-misc-info (delq 'tracking-mode-line-buffers
-                                    mode-line-misc-info)
-          mode-line-format (delq 'tracking-mode-line-buffers
-                                 mode-line-format))
+                                    mode-line-misc-info))
+    (setq-default mode-line-format (delq 'tracking-mode-line-buffers
+                                         (default-value 'mode-line-format)))
     (remove-hook 'window-configuration-change-hook
                  'tracking-remove-visible-buffers))))
 


### PR DESCRIPTION
- lisp/tracking.el (tracking-mode): Use `setq-default' and
  `default-value' for `mode-line-format'.
