### PR TITLE
Fix fixed dependency syntax

### DIFF
--- a/circe-pkg.el
+++ b/circe-pkg.el
@@ -1,2 +1,2 @@
 (define-package "circe" "1.6" "Client for IRC in Emacs"
-  '(("cl-lib" "0.5")))
+  '((cl-lib "0.5")))


### PR DESCRIPTION
The package name must be a symbol, and not a string.