### PR TITLE
scripts/compile: fix `find` command for OSX

### DIFF
--- a/scripts/compile
+++ b/scripts/compile
@@ -3,7 +3,7 @@
 set -e
 cd "$(dirname "$0")/.."
 
-find -name '*.elc' -delete
+find . -name '*.elc' -delete
 cask exec "${EMACS:-emacs}" -batch \
      -L . \
      --eval "(setq byte-compile-warnings '(not cl-functions))" \


### PR DESCRIPTION
As written, the script fails with the following error:
```
==> scripts/compile
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```