### PR TITLE
Add URL meta-data to package file

### DIFF
--- a/circe-pkg.el
+++ b/circe-pkg.el
@@ -1,2 +1,3 @@
 (define-package "circe" "2.0" "Client for IRC in Emacs"
-  '((cl-lib "0.5")))
+  '((cl-lib "0.5"))
+  :url "https://github.com/jorgenschaefer/circe")


### PR DESCRIPTION
Enable Emacs to understand package's homepage, for example, via
'C-h P circe`.

Without the fix, the homepage can't be displayed correctly:
![2015-08-12 3 50 55](https://cloud.githubusercontent.com/assets/4550353/9209546/b42cd6f4-40a9-11e5-820e-2c9839fc09bc.png)
(tested on Emacs 25.0.50.5, built from git repo recently)