### PR TITLE
Changed some of the default faces

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -65,14 +65,19 @@
   :group 'circe)
 
 (defface circe-server-face
-  '((((type tty)) :foreground "blue" :weight bold)
+  '((((type tty)) (:foreground "blue" :weight bold))
+    (((background dark)) (:foreground "#5095cf"))
+    (((background light)) (:foreground "#3840b0"))
     (t (:foreground "SteelBlue")))
   "The face used to highlight server messages."
   :group 'circe)
 
 (defface circe-highlight-nick-face
-  '((((type tty)) (:foreground "cyan" :weight bold))
-    (t (:foreground "CadetBlue3" :weight bold)))
+  '((default (:weight bold))
+    (((type tty)) (:foreground "cyan"))
+    (((background dark)) (:foreground "#82e2ed"))
+    (((background light)) (:foreground "#0445b7"))
+    (t (:foreground "CadetBlue3")))
   "The face used to highlight messages directed to us."
   :group 'circe)
 

--- a/lui-irc-colors.el
+++ b/lui-irc-colors.el
@@ -46,187 +46,52 @@
   "Face used for inverse video."
   :group 'lui-irc-colors)
 
-(defface lui-irc-colors-fg-0-face
-  '((((class color)) (:foreground "white"))
-    (t (:foreground "white")))
-  "Face used for foreground IRC color 0 (white)."
-  :group 'lui-irc-colors)
+(defun lui-irc-defface (face property on-dark on-light rest doc)
+  (custom-declare-face
+   face
+   `((((type graphic) (class color) (background dark))
+      (,property ,on-dark))
+     (((type graphic) (class color) (background light))
+      (,property ,on-light))
+     (t (,property ,rest)))
+   doc
+   :group 'lui-irc-colors))
 
-(defface lui-irc-colors-fg-1-face
-  '((t (:foreground "black")))
-  "Face used for foreground IRC color 1 (black)."
-  :group 'lui-irc-colors)
+(defun lui-irc-defface-pair (number on-dark on-light rest name)
+  (lui-irc-defface
+   (intern (format "lui-irc-colors-fg-%d-face" number))
+   :foreground
+   on-dark on-light rest
+   (concat "Face used for foreground IRC color "
+	   (number-to-string n) " (" name ")."))
+  (lui-irc-defface
+   (intern (format "lui-irc-colors-bg-%d-face" number))
+   :background
+   on-light on-dark rest
+   (concat "Face used for background IRC color "
+	   (number-to-string n) " (" name ").")))
 
-(defface lui-irc-colors-fg-2-face
-  '((((class color)) (:foreground "blue4"))
-    (t (:foreground "blue")))
-  "Face used for foreground IRC color 2 (blue)."
-  :group 'lui-irc-colors)
+(defun lui-irc-defface-bulk (colors)
+  (dotimes (n (length colors))
+    (apply 'lui-irc-defface-pair n (nth n colors))))
 
-(defface lui-irc-colors-fg-3-face
-  '((t (:foreground "green4")))
-  "Face used for foreground IRC color 3 (green)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-4-face
-  '((((class color)) (:foreground "red"))
-    (t (:foreground "red")))
-  "Face used for foreground IRC color 4 (red)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-5-face
-  '((((class color)) (:foreground "red4"))
-    (t (:foreground "red")))
-  "Face used for foreground IRC color 5 (brown)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-6-face
-  '((((class color)) (:foreground "magenta4"))
-    (t (:foreground "magenta")))
-  "Face used for foreground IRC color 6 (purple)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-7-face
-  '((((class color)) (:foreground "yellow4"))
-    (t (:foreground "yellow")))
-  "Face used for foreground IRC color 7 (orange)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-8-face
-  '((((class color)) (:foreground "yellow"))
-    (t (:foreground "yellow")))
-  "Face used for foreground IRC color 8 (yellow)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-9-face
-  '((((class color)) (:foreground "green"))
-    (t (:foreground "green")))
-  "Face used for foreground IRC color 9 (light green)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-10-face
-  '((((class color)) (:foreground "cyan4"))
-    (t (:foreground "cyan")))
-  "Face used for foreground IRC color 10 (teal)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-11-face
-  '((((class color)) (:foreground "cyan"))
-    (t (:foreground "cyan")))
-  "Face used for foreground IRC color 11 (light cyan)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-12-face
-  '((((class color)) (:foreground "blue"))
-    (t (:foreground "blue")))
-  "Face used for foreground IRC color 12 (light blue)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-13-face
-  '((((class color)) (:foreground "magenta"))
-    (t (:foreground "magenta")))
-  "Face used for foreground IRC color 13 (pink)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-14-face
-  '((((class color)) (:foreground "dimgray"))
-    (t (:foreground "gray")))
-  "Face used for foreground IRC color 14 (grey)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-fg-15-face
-  '((((class color)) (:foreground "gray"))
-    (t (:foreground "gray")))
-  "Face used for foreground IRC color 15 (light grey)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-0-face
-  '((((class color)) (:background "white"))
-    (t (:background "white")))
-  "Face used for background IRC color 0 (white)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-1-face
-  '((t (:background "black")))
-  "Face used for background IRC color 1 (black)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-2-face
-  '((((class color)) (:background "blue4"))
-    (t (:background "blue")))
-  "Face used for background IRC color 2 (blue)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-3-face
-  '((t (:background "green4")))
-  "Face used for background IRC color 3 (green)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-4-face
-  '((t (:background "red")))
-  "Face used for background IRC color 4 (red)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-5-face
-  '((((class color)) (:background "red4"))
-    (t (:background "red")))
-  "Face used for background IRC color 5 (brown)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-6-face
-  '((((class color)) (:background "magenta4"))
-    (t (:background "magenta")))
-  "Face used for background IRC color 6 (purple)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-7-face
-  '((((class color)) (:background "yellow4"))
-    (t (:background "yellow")))
-  "Face used for background IRC color 7 (orange)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-8-face
-  '((t (:background "yellow")))
-  "Face used for background IRC color 8 (yellow)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-9-face
-  '((t (:background "green")))
-  "Face used for background IRC color 9 (light green)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-10-face
-  '((((class color)) (:background "cyan4"))
-    (t (:background "cyan")))
-  "Face used for background IRC color 10 (teal)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-11-face
-  '((t (:background "cyan")))
-  "Face used for background IRC color 11 (light cyan)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-12-face
-  '((t (:background "blue")))
-  "Face used for background IRC color 12 (light blue)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-13-face
-  '((t (:background "magenta")))
-  "Face used for background IRC color 13 (pink)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-14-face
-  '((((class color)) (:background "dimgray"))
-    (t (:background "gray")))
-  "Face used for background IRC color 14 (grey)."
-  :group 'lui-irc-colors)
-
-(defface lui-irc-colors-bg-15-face
-  '((((class color)) (:background "gray"))
-    (t (:background "gray")))
-  "Face used for background IRC color 15 (light grey)."
-  :group 'lui-irc-colors)
+(lui-irc-defface-bulk
+ '(("#ffffff" "#585858" "white"    "white")
+   ("#a5a5a5" "#000000" "black"    "black")
+   ("#9b9bff" "#0000ff" "blue4"    "blue")
+   ("#40eb51" "#006600" "green4"   "green")
+   ("#ff9696" "#b60000" "red"      "red")
+   ("#d19999" "#8f3d3d" "red4"     "brown")
+   ("#d68fff" "#9c009c" "magenta4" "purple")
+   ("#ffb812" "#7a4f00" "yellow4"  "orange")
+   ("#ffff00" "#5c5c00" "yellow"   "yellow")
+   ("#80ff95" "#286338" "green"    "light green")
+   ("#00b8b8" "#006078" "cyan4"    "teal")
+   ("#00ffff" "#006363" "cyan"     "light cyan")
+   ("#a8aeff" "#3f568c" "blue"     "light blue")
+   ("#ff8bff" "#853885" "magenta"  "pink")
+   ("#cfcfcf" "#171717" "dimgray"  "grey")
+   ("#e6e6e6" "#303030" "gray"     "light grey")))
 
 (defvar lui-irc-colors-regex
   "\\(\x02\\|\x1F\\|\x16\\|\x1D\\|\x0F\\|\x03\\)"


### PR DESCRIPTION
Now they depend on background, and should be legible by default.

The [contrast ratio](http://webaim.org/resources/contrastchecker/) of at least 7 is preserved for adwaita (dark-on-light, background color #ededed) and wombat (light-on-dark, #242424; actually used #303030 to cover more themes) color themes. Tried to not affect `(type tty)`.

The bluish theme is preserved, though not as blue as before: blue is pretty dark by itself, so it limits the options for a light-on-dark theme.