### PR TITLE
Fix irc--parse to work with Slack gateway

### DIFF
--- a/irc.el
+++ b/irc.el
@@ -176,17 +176,28 @@ COMMAND arg1 arg2 :arg3 still arg3
     (goto-char (point-min))
     (let ((sender nil)
           (args nil))
-      (when (looking-at ":\\([^ ]*\\) +")
+      ;; Optional sender.
+      (when (looking-at ":\\([^ ]+\\) ")
         (setq sender (decode-coding-string
                       (match-string 1)
                       'undecided))
         (goto-char (match-end 0)))
-      (while (re-search-forward ":\\(.*\\)\\|\\([^ ]+\\)" nil t)
+
+      ;; COMMAND.
+      (unless (looking-at "\\([^ ]+\\)")
+        (error "Invalid message: %s" line))
+      (push (decode-coding-string (match-string 1) 'undecided)
+            args)
+      (goto-char (match-end 0))
+
+      ;; Arguments.
+      (while (re-search-forward " :\\(.*\\)\\| \\([^ ]*\\)" nil t)
         (push (decode-coding-string
                (or (match-string 1)
                    (match-string 2))
                'undecided)
               args))
+
       (cons sender (nreverse args)))))
 
 (defun irc-userstring-nick (userstring)

--- a/tests/test-irc.el
+++ b/tests/test-irc.el
@@ -230,6 +230,11 @@
             :to-equal
             '(nil "COMMAND" "arg1" "arg2")))
 
+  (it "should treat single space as argument separator"
+      (expect (irc--parse "COMMAND arg1  arg3")
+              :to-equal
+              '(nil "COMMAND" "arg1" "" "arg3")))
+
   (it "should parse a command with rest argument"
     (expect (irc--parse "COMMAND arg1 arg2 :arg3 still arg3")
             :to-equal


### PR DESCRIPTION
Slack IRC gateway sends following messages:

  ":irc.tinyspeck.com 333 nick #channel  0"

Note the double-space at the end -- the `setter` argument is
missing (see `circe-display-333`).

According to RFC2812, section 2.3:

  The prefix, command, and all parameters are separated by one ASCII
  space character (0x20) each.

Could be relevant to GitHub issue #148.