### PR TITLE
Fix margin time stamp position

### DIFF
--- a/lui.el
+++ b/lui.el
@@ -1316,7 +1316,8 @@ If TEXT is specified, use that instead of formatting a new time stamp."
                 (not lui-time-stamp-last)
                 (not (string= ts lui-time-stamp-last)))
         (goto-char (point-min))
-        (goto-char (point-at-eol))
+        (when lui-fill-type
+          (goto-char (point-at-eol)))
         (let* ((ts (propertize ts 'face 'lui-time-stamp-face))
                (ts-margin (propertize
                            " "


### PR DESCRIPTION
I don't know if there is a specific reason to put the text for the time stamp margin at the end of the line, so I only changed it for my specific use case. Please let me know what you think.

---

Put the time stamp display text at the beginning of the line when
`lui-time-stamp-position` is either left-margin or right-margin and
`lui-fill-type` is nil.

When `lui-fill-type` has a value of nil, `visual-line-mode` is enabled
and the `lui-time-stamp-position` is either left-margin or
right-margin the time stamp appears in the margin of the last line of
the message. For all other situations it appears in the margin of the
first line of the message.