### PR TITLE
add when text check, add CTCP PING test

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -2952,7 +2952,8 @@ Arguments are either of the two:
                    :userhost (or userhost "server")
                    :target target
                    :body (or text "")
-                   :ago (let ((time (string-to-number text)))
+                   :ago (let ((time (when text
+				      (string-to-number text))))
                           (if time
                               (format "%.2f seconds" (- (float-time) time))
                             "unknown seconds")))))

--- a/tests/test-circe.el
+++ b/tests/test-circe.el
@@ -218,4 +218,19 @@
         (expect 'circe-display
                 :to-have-been-called-with
                 'circe-format-action
-                :nick "nick" :userhost "user@host" :body "the text")))))
+                :nick "nick" :userhost "user@host" :body "the text")))
+    
+    (describe "CTCP PING"
+      (it "should display unknown seconds when passed nil for text"
+	(spy-on 'circe-server-my-nick-p :and-return-value nil) 
+	(spy-on 'circe-server-get-or-create-chat-buffer
+		:and-return-value (current-buffer))
+	(spy-on 'circe-display)
+	
+	(circe-display-ctcp-ping "nick" "user@host" "irc.ctcp.PING"
+				 "target" nil)
+
+	(expect 'circe-display
+		:to-have-been-called-with
+		'circe-format-server-ctcp-ping
+		:nick "nick" :userhost "user@host" :target "target" :body "" :ago "unknown seconds")))))


### PR DESCRIPTION
test in test-circe.el checks specifically that a message-text of nil is translated to (and subsequently passed to circe-display as) "unknown seconds"

Couldn't get cask set up to test this, so I tested it by buttercup-run-discover. If someone can do the cask check and confirm it works on all supported versions, that'd be great.

fixes #296

