### PR TITLE
Remove OpenSSL's s_client fallback

### DIFF
--- a/make-tls-process.el
+++ b/make-tls-process.el
@@ -28,9 +28,8 @@
 (require 'tls)
 
 (defcustom tls-connection-command
-  (if (executable-find "gnutls-cli")
-      "gnutls-cli --insecure -p %p %h"
-    "openssl s_client -connect %h:%p -ign_eof")
+  (when (executable-find "gnutls-cli")
+    "gnutls-cli --insecure -p %p %h")
   "The command to use to create a TLS connection.
 
 %h is replaced with server hostname, %p with port to connect to.


### PR DESCRIPTION
It has been argued in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=766397 that OpenSSL's `s_client` command should not be used for anything else than debugging.  As I've witnessed several cases of people who didn't have GnuTLS installed and therefore used OpenSSL as fallback not being able to tell why their IRC connection failed silently I'd prefer supporting GnuTLS only and get an error if it wasn't found.