### PR TITLE
Add a stats command to circe

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -2797,8 +2797,8 @@ Arguments are IGNORED."
   "Request statistics from a server."
   (interactive)
   ;; Split string into query and server if we can
-  (setq query (split-string query))
-  (irc-send-STATS (circe-server-process) (first query) (second query)))
+  (let ((query (split-string query)))
+    (irc-send-STATS (circe-server-process) (car query) (cadr query))))
 
 (defun circe-command-WL (&optional split)
   "Show the people who left in a netsplit.

--- a/circe.el
+++ b/circe.el
@@ -2793,6 +2793,13 @@ Arguments are IGNORED."
   (let ((whom (string-trim whom)))
     (irc-send-WHOWAS (circe-server-process) whom)))
 
+(defun circe-command-STATS (query)
+  "Request statistics from a server."
+  (interactive)
+  ;; Split string into query and server if we can
+  (setq query (split-string query))
+  (irc-send-STATS (circe-server-process) (first query) (second query)))
+
 (defun circe-command-WL (&optional split)
   "Show the people who left in a netsplit.
 Without any arguments, shows shows the current netsplits and how

--- a/irc.el
+++ b/irc.el
@@ -467,6 +467,12 @@ MODE should be an integer as per RFC 2812"
   "Retrieve past whois information on TARGET."
   (irc-send-command conn "WHOWAS" target))
 
+(defun irc-send-STATS (conn query &optional server)
+  "Return statistics on current server, or SERVER if it is specified."
+  (if server
+      (irc-send-command conn "STATS" query server)
+    (irc-send-command conn "STATS" query)))
+
 ;;;;;;;;;;;;;;;
 ;;; Debug stuff
 

--- a/tests/test-irc.el
+++ b/tests/test-irc.el
@@ -685,7 +685,15 @@
 
       (expect 'irc-send-raw
               :to-have-been-called-with
-              'proc "WHOWAS user"))))
+              'proc "WHOWAS user")))
+
+  (describe "`irc-send-STATS'"
+    (it "should send a STATS message"
+      (irc-send-STATS 'proc "q" "irc.local")
+
+        (expect 'irc-send-raw
+                :to-have-been-called-with
+                'proc "STATS q irc.local"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Handler: Registration


### PR DESCRIPTION
This PR adds a stats command to circe. In order to avoid combinining the multiple args (eg: `/stats p adams.freenode.net`), I split the incoming argument string. Let me know if you think there's a cleaner way to do this, I'm not sure what exactly the convention is here.

I could also use `irc-send-raw`, but that seems more hacky to me. 

Also see [the stats command](https://en.wikipedia.org/wiki/List_of_Internet_Relay_Chat_commands#STATS) for sytax.

I'm adding this because in the topic of `#freenode`, it says:

```
*** Topic for #freenode: Welcome to #freenode | Feel free to message
    staff at any time. You can find us using /stats p (shows
    immediately-available staff) or /who freenode/staff/* (shows all
    staff) |
```

which dosen't work in circe, as there is no stats command.

Let me know if anything seems off.