### PR TITLE
Fix nick colors if nick hasn't spoken yet

### DIFF
--- a/circe-color-nicks.el
+++ b/circe-color-nicks.el
@@ -242,19 +242,14 @@ be mutated."
   "Hash-table from nicks to colors.")
 
 (defun circe-nick-color-nick-list ()
-  "Return list of all nicks that have a color assigned to them.
+  "Return list of all nicks that should be colored in this channel.
 Own and blacklisted nicks are excluded."
   (let ((our-nick (circe-nick))
-        (channel-nicks (circe-channel-nicks))
-        nicks)
-    (maphash
-     (lambda (nick color)
-       (when (and (member nick channel-nicks)
-                  (not (string= our-nick nick))
-                  (not (member nick circe-color-nicks-message-blacklist)))
-         (push nick nicks)))
-     circe-nick-color-mapping)
-    nicks))
+        (channel-nicks (circe-channel-nicks)))
+    (cl-remove-if (lambda (nick)
+                    (or (string= our-nick nick)
+                        (member nick circe-color-nicks-message-blacklist)))
+                  channel-nicks)))
 
 (defvar circe-nick-color-timestamps (make-hash-table :test 'equal)
   "Hash-table from colors to the timestamp of their last use.")
@@ -321,7 +316,7 @@ See `circe-nick-color-pick', which is where this is used."
         (when body
           (with-syntax-table circe-nick-syntax-table
             (goto-char body)
-            (let* ((nicks (circe-channel-nicks))
+            (let* ((nicks (circe-nick-color-nick-list))
                    (regex (regexp-opt nicks 'words)))
               (let (case-fold-search)
                 (while (re-search-forward regex nil t)

--- a/circe-color-nicks.el
+++ b/circe-color-nicks.el
@@ -321,7 +321,7 @@ See `circe-nick-color-pick', which is where this is used."
         (when body
           (with-syntax-table circe-nick-syntax-table
             (goto-char body)
-            (let* ((nicks (circe-nick-color-nick-list))
+            (let* ((nicks (circe-channel-nicks))
                    (regex (regexp-opt nicks 'words)))
               (let (case-fold-search)
                 (while (re-search-forward regex nil t)

--- a/tests/test-circe-color-nicks.el
+++ b/tests/test-circe-color-nicks.el
@@ -1,0 +1,18 @@
+;; -*-lexical-binding: t-*-
+
+(require 'circe)
+(require 'circe-color-nicks)
+
+(describe "The `circe-color-nicks-message-blacklist' variable"
+  (before-each
+    (spy-on 'circe-nick :and-return-value "mynick")
+    (spy-on 'circe-channel-nicks :and-return-value '("a" "b" "c" "d" "mynick")))
+
+  (it "Should return all other nicks."
+    (expect (circe-nick-color-nick-list)
+            :to-equal '("a" "b" "c" "d")))
+  (it "Should not include entries in the blacklist"
+    (let ((circe-color-nicks-message-blacklist '("b" "d")))
+      (expect (circe-nick-color-nick-list)
+              :to-equal '("a" "c")))))
+


### PR DESCRIPTION
If a nick hasn't been colored yet (perhaps they haven't spoken yet), they won't have an entry in circe-nick-color-mapping. If they don't have an entry, `circe-nick-color-nick-list` will not return them in the list. This results in a couple of nicks not being colored if they haven't spoken yet or if the table is flushed.

I'm not sure if this will have an adverse effect on performance, but I don't think it will because the `circe-nick-color-nick-list` is doing a bunch of additional processing that was removed as well. I don't know if it's enough to compensate for the extra time spent in `regexp-opt` (I assume that will happen), but from using this for a couple days, I don't see any huge differences.

This removes all usages of `circe-nick-color-nick-list` let me know if it's ok to just remove that.

If there was a reason for not just using `circe-channel-nicks` directly, let me know, I could have missed something (in which case this can be closed, probably).