### PR TITLE
Shorten only the buffer names we have ever tracked

### DIFF
--- a/tests/test-tracking.el
+++ b/tests/test-tracking.el
@@ -7,5 +7,18 @@
     (expect (text-properties-at
              0
              (car (tracking-shorten
-                   (list (propertize (buffer-name) 'face 'foo)))))
+                   (list (propertize (buffer-name) 'face 'foo))
+                   (list (buffer-name)))))
             :to-equal '(face foo))))
+
+(describe "The `tracking-add-buffer' function"
+  (it "should add buffers to `tracking-all-buffers'"
+    (let ((tracking-all-buffers ()))
+      (tracking-add-buffer (get-buffer-create "my-cool-buffer"))
+      (expect tracking-all-buffers
+              :to-equal '("my-cool-buffer"))))
+  (it "should not add buffers to `tracking-all-buffers' if already present"
+    (let ((tracking-all-buffers '("my-cool-buffer")))
+      (tracking-add-buffer (get-buffer-create "my-cool-buffer"))
+      (expect tracking-all-buffers
+              :to-equal '("my-cool-buffer")))))


### PR DESCRIPTION
shorten-strings seems like it could be quadratic or worse, so having
fewer things to shorten could make things more responsive.

This is a win for users who have lots and lots of buffers, but
relatively few Circe buffers. It keeps track of all buffers that have
ever been tracked forever, so it could potentially be a loss for
people who keep very few buffers open, but cycle through lots of Circe
buffers.

Refs #286 and #344.

I tested this both manually (`eval-buffer` and reconnecting to my znc bouncer) and using the automated tests on emacs 26.1. Of the versions in `scripts/env`, none are "natively" available on NixOS unstable, which is what I'm running, so I didn't test those.