### PR TITLE
Shorten only lui-mode buffer names

### DIFF
--- a/tests/test-tracking.el
+++ b/tests/test-tracking.el
@@ -7,5 +7,20 @@
     (expect (text-properties-at
              0
              (car (tracking-shorten
-                   (list (propertize (buffer-name) 'face 'foo)))))
+                   (list (propertize (buffer-name) 'face 'foo))
+                   (list (buffer-name)))))
             :to-equal '(face foo))))
+
+(describe "The `tracking-all-buffers' function"
+  (it "should keep lui-mode buffers"
+    (let ((lui-mode-buffer (get-buffer-create "will-be-lui-mode")))
+      (with-current-buffer lui-mode-buffer
+        (lui-mode)
+        (expect (mapcar #'buffer-name (tracking-all-buffers))
+                :to-equal '("will-be-lui-mode")))
+      (kill-buffer lui-mode-buffer)))
+
+  (it "should ignore non-lui-mode buffers"
+    (let ((non-lui-mode-buffer (get-buffer-create "won't-be-lui-mode")))
+      (expect (mapcar #'buffer-name (tracking-all-buffers))
+              :to-equal '()))))


### PR DESCRIPTION
shorten-strings seems like it could be quadratic or worse, so having
fewer things to shorten could make things more responsive.

This seems like a violation of the software's layered design (lui
knows about tracking, but tracking doesn't know about lui), but it's
just a symbol name so maybe it's OK. Another alternative is to maybe
define tracking-all-buffers as a hook in tracking and have lui provide
its definition. This makes the interface between lui and tracking a
bit more complicated, though.

Refs #286 and #344.
