### PR TITLE
Add `tracking-shorten-modes' to selectively shorten buffers

### DIFF
--- a/tracking.el
+++ b/tracking.el
@@ -49,6 +49,15 @@ the mode line."
   :type 'boolean
   :group 'tracking)
 
+(defcustom tracking-shorten-modes t
+  "List of major modes to shorten in tracking.
+When set to 't' shorten all modes.
+Setting this to limit the number of buffers shortened improves
+the performance of shortening substantially."
+  :type '(set boolean
+              (repeat symbol))
+  :group 'tracking)
+
 (defcustom tracking-frame-behavior 'visible
   "How to deal with frams to determine visibility of buffers.
 This is passed as the second argument to `get-buffer-window',
@@ -390,12 +399,23 @@ This is usually called via `window-configuration-changed-hook'."
         (tracking-remove-buffer buffer))))))
 
 ;;; Helper functions
+(defun tracking-filter-mode (buffer)
+  "If true, BUFFER should be filtered out of shortened buffers."
+  (unless (eq tracking-shorten-modes t)
+    (not (memq
+          (buffer-local-value 'major-mode buffer)
+          tracking-shorten-modes))))
+
 (defun tracking-shorten (buffers)
   "Shorten BUFFERS according to `tracking-shorten-buffer-names-p'."
   (if tracking-shorten-buffer-names-p
-      (let ((all (shorten-strings (mapcar #'buffer-name (buffer-list)))))
+      (let ((all (shorten-strings
+                  (mapcar #'buffer-name
+                          (cl-remove-if #'tracking-filter-mode
+                                        (buffer-list))))))
         (mapcar (lambda (buffer)
-                  (let ((short (cdr (assoc buffer all))))
+                  (let ((short (or (cdr (assoc buffer all))
+                                   buffer)))
                     (set-text-properties
                      0 (length short)
                      (text-properties-at 0 buffer)


### PR DESCRIPTION
By limiting shortened buffers to those actually using tracking.el or
lui, we can gain a substantial performance improvement for tracking
said buffers (when shortening).

Alternatively, we can add a variable to only shorten currently tracked
buffers (ie: tracking-buffers), which will be even faster.

I actually prefer shortening only the currently tracked buffers even if it
leads to non-deterministic shortening. Do you like that solution more?

See: #286, #346, #344

For me:
```
(benchmark-run 1000 (tracking-shorten nil))
tracking-shorten-modes: t
(8.734324133 8 4.102178583008936)
tracking-shorten-modes: (circe-channel-mode)
(2.075575641 2 1.031831622007303)
```

As you can see, we still have a way to go on this function (and others in the critical path), but it's a start. Unfortunately, it all seems to be in the shortening library (on this particular call). 