### PR TITLE
fix for GH-282: /GQUIT does nothing

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -2512,6 +2512,7 @@ If ARGUMENT is nil, it is interpreted as no argument."
   (interactive "sReason: ")
   (dolist (buf (circe-server-buffers))
     (with-current-buffer buf
+      (setq circe-server-inhibit-auto-reconnect-p t)
       (irc-send-QUIT circe-server-process reason))))
 
 (defun circe-command-HELP (&optional ignored)

--- a/circe.el
+++ b/circe.el
@@ -2512,9 +2512,7 @@ If ARGUMENT is nil, it is interpreted as no argument."
   (interactive "sReason: ")
   (dolist (buf (circe-server-buffers))
     (with-current-buffer buf
-      (when (eq (process-status circe-server-process)
-                'open)
-        (irc-send-QUIT circe-server-process reason)))))
+      (irc-send-QUIT circe-server-process reason))))
 
 (defun circe-command-HELP (&optional ignored)
   "Display a list of recognized commands, nicely formatted."


### PR DESCRIPTION
Apply same fix as in df9a1dc.
While here fix that after /GQUIT circe would immediately try to reconnect.
