### PR TITLE
Reconnect even if some server is not available

### DIFF
--- a/circe-lagmon.el
+++ b/circe-lagmon.el
@@ -103,8 +103,6 @@ run sufficiently often with the timer."
     (with-current-buffer buffer
       (when (and (eq major-mode 'circe-server-mode)
                  circe-server-process
-                 (eq (irc-connection-state circe-server-process)
-                     'registered)
                  (not circe-lagmon-disabled))
         (circe-lagmon-server-check)))))
 
@@ -139,12 +137,14 @@ send a request if it's time for that. See
           (> now
              (+ circe-lagmon-last-send-time
                 circe-lagmon-check-interval)))
-      (irc-send-raw (circe-server-process)
-                    (format "PRIVMSG %s :\C-aLAGMON %s\C-a"
-                            (circe-nick) now)
-                    :nowait)
-      (setq circe-lagmon-last-send-time now
-            circe-lagmon-last-receive-time nil))
+
+      (when (eq (irc-connection-state circe-server-process) 'registered)
+        (setq circe-lagmon-last-send-time now
+              circe-lagmon-last-receive-time nil)
+        (irc-send-raw (circe-server-process)
+                      (format "PRIVMSG %s :\C-aLAGMON %s\C-a"
+                              (circe-nick) now)
+                      :nowait)))
      )))
 
 (defun circe-lagmon-force-mode-line-update ()


### PR DESCRIPTION
This is quite difficult to debug and pinpoint the exact root
of the issue but my theory is following.

If there is an IRC server that is available only via VPN (or for
some other reason it is not available at all times), then after
disconnecting from that VPN (I do that concurrently with reconnecting
to a different wireless network connection) you won't get automatically
reconnected to IRC anymore. Running `M-x circe-reconnect` manually
workarounds the issue though.

The problem is that

1) `circe-lagmon-server-check` is never called from
   `circe-lagmon-timer-tick` because
   `(irc-connection-state circe-server-process)` returns
   `'connecting'` forever

2) `irc-send-raw` ends with an error because the server is not
   available and because of the error, other servers are not even
   tried. Therefore `circe-lagmon-last-send-time` is never set
   to anything and therefore we won't ever timeout.

This commit seems to fix the issue and hopefully it doesn't break
any current use-case.