### PR TITLE
Dont use deprecated variables

### DIFF
--- a/circe-display-images.el
+++ b/circe-display-images.el
@@ -124,7 +124,7 @@ the image. See `circe-display-images-text-property-map' for more details."
   (interactive)
   (let*
       ((inhibit-read-only t)
-       (url (url-get-url-at-point))
+       (url (thing-at-point-url-at-point))
        (image-data(gethash url circe-display-images-text-property-map))
        (display-image-p (plist-get image-data :display-image-p))
        (image-property-of-url (plist-get image-data :image-property))

--- a/circe.el
+++ b/circe.el
@@ -1364,7 +1364,7 @@ lui-mode
   (setq lui-input-function 'circe--input
         default-directory (expand-file-name circe-default-directory)
         circe-server-last-active-buffer (current-buffer)
-        flyspell-generic-check-word-p 'circe--flyspell-check-word-p)
+        flyspell-generic-check-word-predicate 'circe--flyspell-check-word-predicate)
   (when circe-use-cycle-completion
     (set (make-local-variable 'completion-cycle-threshold)
          t))
@@ -1601,11 +1601,11 @@ using the /SAY command."
 ;;;; Flyspell ;;;;
 ;;;;;;;;;;;;;;;;;;
 
-(defun circe--flyspell-check-word-p ()
+(defun circe--flyspell-check-word-predicate ()
   "Return a true value if flyspell check the word before point.
 
-This is a suitable value for `flyspell-generic-check-word-p'. It
-will also call `lui-flyspell-check-word-p'."
+This is a suitable value for `flyspell-generic-check-word-predicate'. It
+will also call `flyspell-generic-check-word-predicate'."
   (cond
    ((not (lui-flyspell-check-word-p))
     nil)

--- a/lui.el
+++ b/lui.el
@@ -1309,7 +1309,7 @@ If TEXT is specified, use that instead of formatting a new time stamp."
 
 (defun lui-time-stamp-enable-filtering ()
   "Enable filtering of timestamps from copied text."
-  (set (make-local-variable 'filter-buffer-substring-functions)
+  (set (make-local-variable 'filter-buffer-substring-function)
        '(lui-filter-buffer-time-stamps)))
 
 (defun lui-filter-buffer-time-stamps (fun beg end delete)

--- a/lui.el
+++ b/lui.el
@@ -689,7 +689,10 @@ Otherwise, we move to the next button."
       (message "No such symbol %s" name)
       (ding))
      (t
-      (help-xref-interned sym)))))
+      (with-suppressed-warnings ((obsolete help-xref-interned))
+        (if (fboundp 'describe-symbol)
+            (describe-symbol sym)
+          (help-xref-interned sym))))))
 
 (defun lui-button-pep (number)
   "Browse the PEP NUMBER."

--- a/lui.el
+++ b/lui.el
@@ -470,7 +470,7 @@ It can be customized for an application by specifying a
         lui-output-marker (make-marker)
         lui-input-ring (make-ring lui-input-ring-size)
         lui-input-ring-index nil
-        flyspell-generic-check-word-p 'lui-flyspell-check-word-p)
+        flyspell-generic-check-word-predicate 'lui-flyspell-check-word-predicate)
   (set-marker lui-input-marker (point-max))
   (set-marker lui-output-marker (point-max))
   (add-hook 'window-scroll-functions 'lui-scroll-window nil t)


### PR DESCRIPTION
This replaces some deprecated symbols with their replacements.
There's another one but that requires emacs 27.1:
```
circe-display-images.el:127:14: Warning: ‘url-get-url-at-point’ is an obsolete
    function (as of 27.1); use ‘thing-at-point-url-at-point’ instead.
```