### PR TITLE
Makes ImageMagick image creation optional

### DIFF
--- a/circe-display-images.el
+++ b/circe-display-images.el
@@ -161,10 +161,7 @@ the image. See `circe-display-images-text-property-map' for more details."
                          (goto-char (point-min))
                          (search-forward "\n\n")
                          (buffer-substring (point) (point-max))))
-                 (img (create-image
-                       data 'imagemagick t
-                       :max-height circe-display-images-max-height
-                       :background circe-display-images-background)))
+                 (img (circe-create-image data)))
             (when img
               (insert-image img)
               ;; Store the image so that we can toggle it on and off later. We
@@ -178,6 +175,15 @@ the image. See `circe-display-images-text-property-map' for more details."
               (when circe-display-images-animate-gifs
                 (image-animate img))))
         (kill-buffer buffer)))))
+
+(defconst circe-image-type (if (image-type-available-p 'imagemagick) 'imagemagick nil)
+  "Imagemagick image type if Emacs was compiled with support for ImageMagick, otherwise nil")
+
+(defun circe-create-image (data)
+  "Attempt to create image using Imagemagick type if available, otherwise guess type"
+  (create-image data circe-image-type t
+                :max-height circe-display-images-max-height
+                :background circe-display-images-background))
 
 (defun circe-display-images-urls-in-body ()
   "Return all urls that match the circe-display-images-image-regex"


### PR DESCRIPTION
Recent versions of emacs no longer use ImageMagick by default to display images: https://github.com/emacs-mirror/emacs/blob/emacs-27.1/etc/NEWS#L96-L98

Consequently, some emacs binary package maintainers are compiling emacs without ImageMagick support.

For example, on Arch Linux, notice how libmagick6 is listed as a dependency of an older version of emacs:
https://aur.archlinux.org/packages/emacs-24bit/

but not the latest emacs package:
https://www.archlinux.org/packages/extra/x86_64/emacs/

We can even see when libmagick was removed as a dependency:
https://github.com/archlinux/svntogit-packages/commit/f687dac70acd9a56279fbf0f8b34bf6a9865ba3b#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a 

This breaks circe-display-images on versions of emacs >= 27.1.

One could always download the emacs sources and compile after 'configure --with-imagemagick', at the cost of losing automatic package management.

A better solution would be to use ImageMagick only if it's available,  otherwise fall back to emacs's recent default image creation mechanism: this is what this PR implements.
