### PR TITLE
irc: defer to nsm to verify certificate errors

### DIFF
--- a/irc.el
+++ b/irc.el
@@ -89,8 +89,7 @@ COMMAND conn sender args... -- An IRC command message was received"
                            (cons 'gnutls-x509pki
                                  (gnutls-boot-parameters
                                   :type 'gnutls-x509pki
-                                  :hostname host
-                                  :verify-error t))))
+                                  :hostname host))))
          (proc (funcall fun
                        :name (or (plist-get keywords :name) host)
                        :host host


### PR DESCRIPTION
Sometimes it is necessary to override the certificate checks for a
given host. However this is only possible if the Network Security
Manager gets to verify the connection which it will not of gnutls
refused to complete the connection in the first place.

As a note for reference you can override nsm-temporary-host-settings
with something like:

    (let ((id (nsm-id "irc.badcert.host" 6697)))
      (setq nsm-temporary-host-settings
            (list (list :id id :conditions '(:no-host-match :expired :invalid :verify-cert)))))

This follows the same format as nsm-permanent-host-settings which is
cached in ~/.emacs.d/network-security.data and is where things are set
interactively when using browsers like eww or gnus.