### PR TITLE
Add `:verify-error t` when using new gnutls library

### DIFF
--- a/irc.el
+++ b/irc.el
@@ -91,6 +91,7 @@ COMMAND conn sender args... -- An IRC command message was received"
                                  (gnutls-boot-parameters
                                   :type 'gnutls-x509pki
                                   :hostname host
+                                  :verify-error t
                                   :keylist tls-keylist))))
          (proc (funcall fun
                        :name (or (plist-get keywords :name) host)


### PR DESCRIPTION
Test `should call make-network-process if tls was requested` is
expecting `:verify-error t` but currently its value nil.

According to the documentation the value of this keyword must be `t`
to verify the peer certificate and the peer hostname.

The test was also failing.