### PR TITLE
Fix test `should call make-network-process if tls was requested`

### DIFF
--- a/tests/test-irc.el
+++ b/tests/test-irc.el
@@ -10,8 +10,7 @@
   (cons 'gnutls-x509pki
         (gnutls-boot-parameters
          :type 'gnutls-x509pki
-         :hostname "irc.local"
-         :verify-error t)))
+         :hostname "irc.local")))
 
 (describe "The `irc-connect' function"
   :var (process-status)


### PR DESCRIPTION
The test was expecting `:verify-error t` but it's not longer passed to the `irc-connect` function.