### PR TITLE
Improve the implementation of SASL authentication

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -185,7 +185,9 @@ Common options:
   :sasl-username - The username for SASL authentication.
   :sasl-password - The password for SASL authentication.
   :sasl-external - Option to specify if SASL EXTERNAL authentication should
-                   be used."
+                   be used.
+  :sasl-strict - If SASL authentication is requested and it fails leave the
+                 server."
   :type '(alist :key-type string :value-type plist)
   :group 'circe)
 
@@ -873,6 +875,10 @@ If a function is set it will be called with the value of `circe-host'.")
   "Use SASL external authentication.")
 (make-variable-buffer-local 'circe-sasl-external)
 
+(defvar circe-sasl-strict nil
+  "Use SASL authentication in strict mode.")
+(make-variable-buffer-local 'circe-sasl-strict)
+
 (defvar circe-tls-keylist nil
   "Client certificates to use when connecting via TLS.")
 (make-variable-buffer-local 'circe-tls-keylist)
@@ -1250,6 +1256,7 @@ Do not use this directly, use `circe-reconnect'"
          :tls circe-use-tls
          :tls-keylist circe-tls-keylist
          :sasl-external circe-sasl-external
+         :sasl-strict circe-sasl-strict
          :ip-family circe-ip-family
          :handler-table (circe-irc-handler-table)
          :server-buffer (current-buffer)


### PR DESCRIPTION
This PR adds support for all the possible events sent during SASL
authentication:

 - RPL_SASLSUCCESS
 - ERR_SASLFAILED
 - ERR_SASLTOOLONG
 - ERR_SASLABORTED
 - ERR_SASLALREADY

It also improves the registration logic in this way:

1. When using SASL on successful authentication the server will send 900 and
903. Right now on 900 the `sasl.login` event is always emitted even if we are
doing SASL authentication. This PR waits for the 903 when SASL negotiation is
ongoing. If SASL is not active the `sasl.login` will be emitted when 900 is
sent.

2. Right now the `CAP END` command is sent right after the `AUTHENTICATION` has
been sent without waiting for a response from the server. This PR also delays
the `CAP END` until we know the status of the SASL authentication (success,
failed or aborted).

3. It also adds a new flag `:sasl-strict` that makes the connection with the
server to be closed in the SASL authentication failed.
