### PR TITLE
circe-network-defaults : correct libera nickserv mask and challenge

### DIFF
--- a/circe.el
+++ b/circe.el
@@ -194,8 +194,8 @@ Common options:
 (defvar circe-network-defaults
   '(("Libera Chat" :host "irc.libera.chat" :port (6667 . 6697)
      :tls t
-     :nickserv-mask "^NickServ!NickServ@services\\.$"
-     :nickserv-identify-challenge "\C-b/msg\\s-NickServ\\s-identify\\s-<password>\C-b"
+     :nickserv-mask "^NickServ!NickServ@services\\.libera\\.chat$"
+     :nickserv-identify-challenge "This nickname is registered."
      :nickserv-identify-command "PRIVMSG NickServ :IDENTIFY {nick} {password}"
      :nickserv-identify-confirmation "^You are now identified for \x02.*\x02\\.$"
      :nickserv-ghost-command "PRIVMSG NickServ :GHOST {nick} {password}"


### PR DESCRIPTION
The previous nickserv mask and challenge RE did not match correctly with the libera NOTICE, so automatic nickserv identification did not work. After analysing the raw output using `irc-debug-log`, I found that the RE I provided work (the challenge could be improved).

Feel free to ask questions or offer suggestions.

Best,

Aymeric